### PR TITLE
Set GITOPS_DYNAMIC to true when dynamic plugin loads

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -10,6 +10,12 @@
  */
 [
   {
+    "properties": {
+      "handler": { "$codeRef": "gitopsFlags.enableGitOpsDynamicFlag" }
+    },
+    "type": "console.flag"
+  },
+  {
     "type": "console.navigation/href",
     "properties": {
       "id": "gitops-environment",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "description": "OpenShift Console plugin for GitOps.",
     "exposedModules": {
       "environments": "./components/ApplicationListPage",
-      "detailsPage": "./components/EnvironmentDetailsPageTabs"
+      "detailsPage": "./components/EnvironmentDetailsPageTabs",
+      "gitopsFlags": "./components/utils/flags"
     },
     "dependencies": {
       "@console/pluginAPI": "*"

--- a/src/components/utils/flags/enableGitOpsDynamicFlag.ts
+++ b/src/components/utils/flags/enableGitOpsDynamicFlag.ts
@@ -1,0 +1,6 @@
+import { SetFeatureFlag } from '@openshift-console/dynamic-plugin-sdk';
+
+import { FLAG_GITOPS_DYNAMIC } from '../../../const';
+
+export const enableGitOpsDynamicFlag = (setFeatureFlag: SetFeatureFlag) =>
+  setFeatureFlag(FLAG_GITOPS_DYNAMIC, true);

--- a/src/components/utils/flags/index.ts
+++ b/src/components/utils/flags/index.ts
@@ -1,0 +1,1 @@
+export { enableGitOpsDynamicFlag } from './enableGitOpsDynamicFlag';

--- a/src/const.ts
+++ b/src/const.ts
@@ -6,3 +6,5 @@ export const environmentBaseURI = `/api/gitops/environments`;
 export const environmentBaseURIV2 = `/api/gitops/environment`;
 
 export const fetchDataFrequency = 30;
+
+export const FLAG_GITOPS_DYNAMIC = 'GITOPS_DYNAMIC';


### PR DESCRIPTION
For [GITOPS-3575](https://issues.redhat.com/browse/GITOPS-3575): [DynamicPlugin] Set a flag to toggle static plugin
This PR sets a default true value to GITOPS_DYNAMIC flag which will be monitored by console and display static plugin when dynamic plugin is loaded.