### PR TITLE
upgrade follow-redirects to 1.15.5

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2391,9 +2391,9 @@ focus-trap@6.9.2:
     tabbable "^5.3.2"
 
 follow-redirects@^1.0.0:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
-  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
+  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
 
 forwarded@0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Upgrade follow-redirects to 1.15.5 due to known CVE https://security.snyk.io/vuln/SNYK-JS-FOLLOWREDIRECTS-6141137 

This statisfies https://issues.redhat.com/browse/GITOPS-3767 

Note: follow-redirect is a transitive dependency, so risk of this CVE is very low, but still upgrading it regardless. 
