### PR TITLE
Bump follow-redirects from 1.15.5 to 1.15.6

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3019,9 +3019,9 @@ focus-trap@7.5.2:
     tabbable "^6.2.0"
 
 follow-redirects@^1.0.0:
-  version "1.15.5"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
-  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
 forwarded@0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Fixes CVE-2024-28849

JIRA - https://issues.redhat.com/browse/GITOPS-4405
            https://issues.redhat.com/browse/GITOPS-4254