### PR TITLE
fix: CVE-2024-45296 Backtracking regular expressions cause ReDoS by upgrading path-to-regexp from 1.8.0 to 1.9.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4869,9 +4869,9 @@ path-to-regexp@0.1.7:
   integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
 
 path-to-regexp@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.9.0.tgz#5dc0753acbf8521ca2e0f137b4578b917b10cf24"
+  integrity sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==
   dependencies:
     isarray "0.0.1"
 


### PR DESCRIPTION
This PR fixes [CVE-2024-45296](https://github.com/advisories/GHSA-9wv6-86v2-598j) by upgrading the indirect dependency react-router/path-to-regexp from 1.8.0 to 1.9.0.

The other usage of path-to-regexp 0.1.10 (via `express`) is to be addressed by a separate PR that upgrades `express`, and thus is not changed here.

The dependency after this fix:
```bash
gitops-plugin@0.0.1 /Users/cfang/dev/gitops/gitops-console-plugin
├─┬ @openshift-console/dynamic-plugin-sdk-internal@0.0.11
│ └─┬ react-router@5.2.0
│   └── path-to-regexp@1.9.0 deduped
├─┬ react-router@5.3.4
│ └── path-to-regexp@1.9.0
└─┬ webpack-dev-server@4.15.2
  └─┬ express@4.19.2
    └── path-to-regexp@0.1.7
```