### PR TITLE
Address CVE CVE-2024-43788: webpack version update to 5.94.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ts-loader": "^9.5.1",
     "ts-node": "^10.7.0",
     "typescript": "4.8.4",
-    "webpack": "^5.68.0",
+    "webpack": "^5.94.0",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.9.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2494,7 +2494,7 @@ dompurify@^2.2.6:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.6.tgz#8402b501611eaa7fb3786072297fcbe2787f8592"
   integrity sha512-zUTaUBO8pY4+iJMPE1B9XlO2tXVYIcEA4SNGtvDELzTSCQO7RzH+j7S180BmhmJId78lqGU2z19vgVx2Sxs/PQ==
-  
+
 domutils@^3.0.1, domutils@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2494,7 +2494,7 @@ dompurify@^2.2.6:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.6.tgz#8402b501611eaa7fb3786072297fcbe2787f8592"
   integrity sha512-zUTaUBO8pY4+iJMPE1B9XlO2tXVYIcEA4SNGtvDELzTSCQO7RzH+j7S180BmhmJId78lqGU2z19vgVx2Sxs/PQ==
-
+  
 domutils@^3.0.1, domutils@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
@@ -6887,7 +6887,7 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@^5.68.0, webpack@^5.73.0:
+webpack@^5.73.0, webpack@^5.94.0:
   version "5.94.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.94.0.tgz#77a6089c716e7ab90c1c67574a28da518a20970f"
   integrity sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==


### PR DESCRIPTION
Address [CVE-2024-43788](https://access.redhat.com/security/cve/CVE-2024-43788) webpack: DOM Clobbering vulnerability in AutoPublicPathRuntimeModule