### PR TITLE
Application list page sorting issue (#7821)

### DIFF
--- a/src/gitops/components/application/ApplicationResourcesTab.tsx
+++ b/src/gitops/components/application/ApplicationResourcesTab.tsx
@@ -72,16 +72,33 @@ const ApplicationResourcesTab: React.FC<ApplicationResourcesTabProps> = ({ obj }
   if (resources.length === 0) {
     currentActiveState = DataViewState.empty;
   }
+
+  const COLUMNS_KEYS_INDEXES = React.useMemo(
+    () => [
+      { key: 'name', index: 0 },
+      { key: 'namespace', index: 1 },
+      { key: 'sync-wave', index: 2 },
+      { key: 'sync-status', index: 3 },
+      { key: 'health-status', index: 4 },
+    ],
+    [],
+  );
+
   const [searchParams, setSearchParams] = useSearchParams();
   const { sortBy, direction, onSort } = useDataViewSort({ searchParams, setSearchParams });
-  const getSortParams = (columnId: string, columnIndex: number) => ({
+  const sortByIndex = React.useMemo(
+    () => COLUMNS_KEYS_INDEXES.findIndex((item) => item.key === sortBy),
+    [COLUMNS_KEYS_INDEXES, sortBy],
+  );
+
+  const getSortParams = (columnIndex: number) => ({
     sortBy: {
-      index: columnIndex,
+      index: sortByIndex,
       direction,
       defaultDirection: 'asc' as const,
     },
     onSort: (_event: any, index: number, dir: 'asc' | 'desc') => {
-      onSort(_event, columnId, dir);
+      onSort(_event, COLUMNS_KEYS_INDEXES[index].key, dir);
     },
     columnIndex,
   });
@@ -185,18 +202,11 @@ const sortData = (
     }
 
     if (direction === 'asc') {
-      if (aValue < bValue) {
-        return -1;
-      } else if (aValue > bValue) {
-        return 1;
-      }
-      return 0;
+      // eslint-disable-next-line no-nested-ternary
+      return aValue < bValue ? -1 : aValue > bValue ? 1 : 0;
     } else {
-      if (aValue > bValue) {
-        return -1;
-      } else if (aValue < bValue) {
-        return 1;
-      }
+      // eslint-disable-next-line no-nested-ternary
+      return aValue > bValue ? -1 : aValue < bValue ? 1 : 0;
     }
   });
 };
@@ -204,57 +214,46 @@ const sortData = (
 export const useResourceColumnsDV = (getSortParams) => {
   const columns: DataViewTh[] = [
     {
-      id: 'name',
       cell: t('plugin__gitops-plugin~Name'),
       props: {
-        key: 'name',
         'aria-label': 'name',
         className: 'pf-m-width-25',
-        sort: getSortParams('name', 0),
+        sort: getSortParams(0),
       },
     },
     {
-      id: 'namespace',
       cell: 'Namespace',
       props: {
-        key: 'namespace',
         'aria-label': 'namespace',
         className: 'pf-m-width-20',
-        sort: getSortParams('namespace', 1),
+        sort: getSortParams(1),
       },
     },
     {
-      id: 'sync-wave',
       cell: 'Sync Wave',
       props: {
-        key: 'sync-wave',
         'aria-label': 'sync wave',
         className: 'pf-m-width-15',
-        sort: getSortParams('sync-wave', 2),
+        sort: getSortParams(2),
       },
     },
     {
-      id: 'sync-status',
       cell: 'Sync Status',
       props: {
-        key: 'sync-status',
         'aria-label': 'sync status',
         className: 'pf-m-width-15',
-        sort: getSortParams('sync-status', 3),
+        sort: getSortParams(3),
       },
     },
     {
-      id: 'health-status',
       cell: 'Health Status',
       props: {
-        key: 'health-status',
         'aria-label': 'health status',
         className: 'pf-m-width-15',
-        sort: getSortParams('health-status', 4),
+        sort: getSortParams(4),
       },
     },
     {
-      id: 'actions',
       cell: '',
       props: { 'aria-label': 'actions' },
     },

--- a/src/gitops/components/application/ApplicationSyncStatusTab.tsx
+++ b/src/gitops/components/application/ApplicationSyncStatusTab.tsx
@@ -80,16 +80,31 @@ const ApplicationSyncStatusTab: React.FC<ApplicationSyncStatusTabProps> = ({ obj
   if (resources.length === 0) {
     currentActiveState = DataViewState.empty;
   }
+
+  const COLUMNS_KEYS_INDEXES = React.useMemo(
+    () => [
+      { key: 'name', index: 0 },
+      { key: 'namespace', index: 1 },
+      { key: 'status', index: 2 },
+      { key: 'hook', index: 3 },
+      { key: 'message', index: 4 },
+    ],
+    [],
+  );
   const [searchParams, setSearchParams] = useSearchParams();
   const { sortBy, direction, onSort } = useDataViewSort({ searchParams, setSearchParams });
-  const getSortParams = (columnId: string, columnIndex: number) => ({
+  const sortByIndex = React.useMemo(
+    () => COLUMNS_KEYS_INDEXES.findIndex((item) => item.key === sortBy),
+    [COLUMNS_KEYS_INDEXES, sortBy],
+  );
+  const getSortParams = (columnIndex: number) => ({
     sortBy: {
-      index: columnIndex,
+      index: sortByIndex,
       direction,
       defaultDirection: 'asc' as const,
     },
     onSort: (_event: any, index: number, dir: 'asc' | 'desc') => {
-      onSort(_event, columnId, dir);
+      onSort(_event, COLUMNS_KEYS_INDEXES[index].key, dir);
     },
     columnIndex,
   });
@@ -325,20 +340,11 @@ const sortData = (
     }
 
     if (direction === 'asc') {
-      if (aValue < bValue) {
-        return -1;
-      } else if (aValue > bValue) {
-        return 1;
-      }
-      return 0;
-      // return aValue < bValue ? -1 : aValue > bValue ? 1 : 0;
+      // eslint-disable-next-line no-nested-ternary
+      return aValue < bValue ? -1 : aValue > bValue ? 1 : 0;
     } else {
-      if (aValue > bValue) {
-        return -1;
-      } else if (aValue < bValue) {
-        return 1;
-      }
-      return 0; // return aValue > bValue ? -1 : aValue < bValue ? 1 : 0;
+      // eslint-disable-next-line no-nested-ternary
+      return aValue > bValue ? -1 : aValue < bValue ? 1 : 0;
     }
   });
 };
@@ -346,57 +352,46 @@ const sortData = (
 export const useResourceColumnsDV = (getSortParams) => {
   const columns: DataViewTh[] = [
     {
-      id: 'name',
       cell: t('plugin__gitops-plugin~Name'),
       props: {
-        key: 'name',
         'aria-label': 'name',
         className: 'pf-m-width-25',
-        sort: getSortParams('name', 0),
+        sort: getSortParams(0),
       },
     },
     {
-      id: 'namespace',
       cell: 'Namespace',
       props: {
-        key: 'namespace',
         'aria-label': 'namespace',
         className: 'pf-m-width-20',
-        sort: getSortParams('namespace', 1),
+        sort: getSortParams(1),
       },
     },
     {
-      id: 'status',
       cell: 'Status',
       props: {
-        key: 'status',
         'aria-label': 'status',
         className: 'pf-m-width-15',
-        sort: getSortParams('status', 2),
+        sort: getSortParams(2),
       },
     },
     {
-      id: 'hook',
       cell: 'Hook',
       props: {
-        key: 'hook',
         'aria-label': 'hook',
         className: 'pf-m-width-15',
-        sort: getSortParams('hook', 3),
+        sort: getSortParams(3),
       },
     },
     {
-      id: 'message',
       cell: 'Message',
       props: {
-        key: 'message',
         'aria-label': 'message',
         className: 'pf-m-width-15',
-        sort: getSortParams('message', 4),
+        sort: getSortParams(4),
       },
     },
     {
-      id: 'actions',
       cell: '',
       props: {
         'aria-label': 'actions',

--- a/src/gitops/components/application/History/History.tsx
+++ b/src/gitops/components/application/History/History.tsx
@@ -26,16 +26,31 @@ interface HistoryListProps {
 }
 
 const HistoryList: React.FC<HistoryListProps> = ({ history, obj }) => {
+  const COLUMNS_KEYS_INDEXES = React.useMemo(
+    () => [
+      { key: 'id', index: 0 },
+      { key: 'started-at', index: 1 },
+      { key: 'deployed-at', index: 2 },
+      { key: 'initiated-by', index: 3 },
+      { key: 'revision', index: 4 },
+    ],
+    [],
+  );
+
   const [searchParams, setSearchParams] = useSearchParams();
   const { sortBy, direction, onSort } = useDataViewSort({ searchParams, setSearchParams });
-  const getSortParams = (columnId: string, columnIndex: number) => ({
+  const sortByIndex = React.useMemo(
+    () => COLUMNS_KEYS_INDEXES.findIndex((item) => item.key === sortBy),
+    [COLUMNS_KEYS_INDEXES, sortBy],
+  );
+  const getSortParams = (columnIndex: number) => ({
     sortBy: {
-      index: columnIndex,
+      index: sortByIndex,
       direction,
       defaultDirection: 'asc' as const,
     },
     onSort: (_event: any, index: number, dir: 'asc' | 'desc') => {
-      onSort(_event, columnId, dir);
+      onSort(_event, COLUMNS_KEYS_INDEXES[index].key, dir);
     },
     columnIndex,
   });
@@ -169,12 +184,12 @@ const useRowsDV = (history: ApplicationHistory[], app: ApplicationKind): DataVie
       },
       {
         cell: <Timestamp timestamp={obj.deployStartedAt} />,
-        id: 'deployStartedAt',
+        id: 'started-at',
         dataLabel: 'Deployed Started At',
       },
       {
         cell: <Timestamp timestamp={obj.deployedAt} />,
-        id: 'deployedAt',
+        id: 'deployed-at',
         dataLabel: 'Depoyed At',
       },
       {
@@ -195,48 +210,39 @@ const useRowsDV = (history: ApplicationHistory[], app: ApplicationKind): DataVie
 const useColumnsDV = (getSortParams) => {
   const columns: DataViewTh[] = [
     {
-      id: 'id',
       cell: 'ID',
       props: {
-        key: 'id',
         'aria-label': 'ID',
-        sort: getSortParams('id', 0),
+        sort: getSortParams(0),
       },
     },
     {
       cell: 'Deploy Started At',
-      id: 'deployStartedAt',
       props: {
-        key: `deployStartedAt`,
         className: 'pf-m-width-15',
-        sort: getSortParams('deployStartedAt', 1),
+        sort: getSortParams(1),
       },
     },
     {
       cell: 'Deployed At',
-      id: 'deployedAt',
       props: {
-        key: 'deployedAt',
         className: 'pf-m-width-15',
-        sort: getSortParams('deployedAt', 2),
+        sort: getSortParams(2),
       },
     },
     {
       cell: 'Initiated By',
-      id: 'initiated-by',
       props: {
-        key: 'initiated-by',
         className: 'pf-m-width-15',
-        sort: getSortParams('initiated-by', 3),
+        sort: getSortParams(3),
       },
     },
     {
       cell: 'Revision(s) and Source Repo URL(s)',
-      id: 'revision',
       props: {
         key: 'revision',
         className: 'gitops-admin-plugin__history-id-column pf-m-width-50',
-        sort: getSortParams('revision', 4),
+        sort: getSortParams(4),
       },
     },
   ];
@@ -259,11 +265,11 @@ const sortData = (
         aValue = a.id || '';
         bValue = b.id || '';
         break;
-      case 'deployStartedAt':
+      case 'started-at':
         aValue = a.deployStartedAt || '';
         bValue = b.deployStartedAt || '';
         break;
-      case 'deployedAt':
+      case 'deployed-at':
         aValue = a.deployedAt || '';
         bValue = b.deployedAt || '';
         break;


### PR DESCRIPTION
See GitOps-7821

The sort icons are not updating properly, even though the sorting works.   This PR fixes the sorting for the tables:

Application List Page
Details Page Tabs:
- Resource List Page
- Sync Status Page
- History Page